### PR TITLE
MARP-1053 Adding Filter By Commitish Field for Release Drafter template

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -31,8 +31,8 @@ autolabeler:
     branch:
       - '/(feature)\/.+/'
 replacers:
-  - search: '/MARP-(\d+)/g'
-    replace: '[MARP-$1](https://1ivy.atlassian.net/browse/MARP-$1)'
+  - search: '/([A-Za-z]+-\d+)/g'
+    replace: '[$1](https://1ivy.atlassian.net/browse/$1)'
 commitish: 'master'
 filter-by-commitish: true
 template: |

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -33,6 +33,8 @@ autolabeler:
 replacers:
   - search: '/MARP-(\d+)/g'
     replace: '[MARP-$1](https://1ivy.atlassian.net/browse/MARP-$1)'
+commitish: 'master'
+filter-by-commitish: true
 template: |
   ## Changes
 


### PR DESCRIPTION
- Adding `filter-by-commitish` field to enable the creation of multiple releases in Release Drafter.